### PR TITLE
fix: MapField boundaries lookup no longer swallows geometry on error

### DIFF
--- a/.changeset/mapfield-boundaries-error-handling.md
+++ b/.changeset/mapfield-boundaries-error-handling.md
@@ -1,0 +1,8 @@
+---
+'@aplinkosministerija/design-system': patch
+---
+
+fix: MapField no longer silently drops geometry when the boundaries
+municipality lookup fails (e.g. PostGIS rejects an invalid polygon, 5xx,
+network error). The user's geometry is still applied and the form can
+submit; the error is logged so it remains diagnosable.

--- a/src/components/MapField.tsx
+++ b/src/components/MapField.tsx
@@ -55,21 +55,29 @@ const MapField = ({
             },
           };
 
-          const data = await Boundaries.municipalitiesSearch({
-            requestBody: {
-              filters: [
-                {
-                  geometry: {
-                    method: 'intersects',
-                    geojson: JSON.stringify(geometryWithCrs),
+          try {
+            const data = await Boundaries.municipalitiesSearch({
+              requestBody: {
+                filters: [
+                  {
+                    geometry: {
+                      method: 'intersects',
+                      geojson: JSON.stringify(geometryWithCrs),
+                    },
                   },
-                },
-              ],
-            },
-          });
+                ],
+              },
+            });
 
-          if (!data?.items?.length) {
-            return alert(`Pasirinkta  geometrija nėra Lietuvos teritorijoje`);
+            if (!data?.items?.length) {
+              return alert(`Pasirinkta geometrija nėra Lietuvos teritorijoje`);
+            }
+          } catch (err) {
+            // Boundaries lookup is a best-effort guard; if it fails (e.g. PostGIS
+            // rejects an invalid/self-intersecting polygon, network error, 5xx),
+            // do not silently drop the user's geometry — let the form submit and
+            // rely on server-side validation.
+            console.error('Failed to verify geometry against municipalities', err);
           }
 
           onChange(geojson);


### PR DESCRIPTION
## Summary
- `Boundaries.municipalitiesSearch` is now wrapped in `try/catch` so a failed lookup (e.g. PostGIS rejecting a self-intersecting polygon, 5xx, network blip) no longer silently drops the user's geometry and leaves the form's `geom` unset.
- The "Pasirinkta geometrija nėra Lietuvos teritorijoje" alert is preserved for the genuine success-but-empty case.
- On true call failure we log the error and still call `onChange(geojson)`, so the form can submit and server-side validation makes the final decision.

## Context
Reported on `biip-rusys-web` INVA observation/request forms: pasting many polygon coordinates draws the polygon, but submission fails with *"Privalote pasirinkti vietą žemėlapyje"*. The same data submitted via `biip-admin-web` works because that app uses a local `DrawMap` widget (`biip-admin-web/src/components/other/DrawMap.tsx`) that does not perform this extra boundary check.

Root cause: `handleSaveGeom` `await`s `Boundaries.municipalitiesSearch` with no try/catch. The generated `request.ts` throws `ApiError` on any non-2xx response, so any failure rejects the promise and `onChange` is never called.

Triggered specifically by pasted coordinate lists with duplicated/backtracking points that produce self-intersecting polygons; PostGIS then returns 422/5xx for the intersect query. Smaller polygons (e.g. 4 valid vertices) succeed and submission works.

## Test plan
- [ ] Open an INVA observation/request form via `biip-rusys-web`.
- [ ] Paste polygon coordinates from the original report (self-intersecting). Verify polygon draws, form can be submitted, and a `console.error("Failed to verify geometry against municipalities", …)` appears in DevTools.
- [ ] Paste a simple in-Lithuania polygon. Verify it draws and form submits normally (no console error).
- [ ] Paste an out-of-Lithuania polygon (genuine empty `items`). Verify the original alert still fires and `onChange` is **not** called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)