### PR TITLE
fix(useStorage): guard JSON.parse against corrupt storage values

### DIFF
--- a/.changeset/use-storage-safe-parse.md
+++ b/.changeset/use-storage-safe-parse.md
@@ -1,0 +1,5 @@
+---
+'@aplinkosministerija/design-system': patch
+---
+
+useStorage: guard JSON.parse against corrupt storage values ("undefined", empty or malformed JSON) — they now fall back to initialValue instead of throwing inside render. setValue(undefined) removes the key instead of persisting the literal string "undefined".

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -130,6 +130,21 @@ export const globalStyles = (theme) => `
   }
  `;
 
+// Storage can hold values JSON.parse chokes on: the literal "undefined"
+// (written by setItem(key, JSON.stringify(undefined))), an empty string, or
+// JSON corrupted by interrupted writes. Parsing happens inside a useState
+// initializer, so an unguarded throw crashes the consumer during render.
+function parseStoredValue<T>(raw: string | null, fallback: T): T {
+  if (raw === null || raw === '' || raw === 'undefined') {
+    return fallback;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 export function useStorage<T>(
   key: string,
   initialValue: T,
@@ -139,10 +154,9 @@ export function useStorage<T>(
   setValue: (newValue: T) => void;
   resetValue: () => void;
 } {
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    const item = localStorage.getItem(key);
-    return item ? JSON.parse(item) : initialValue;
-  });
+  const [storedValue, setStoredValue] = useState<T>(() =>
+    parseStoredValue(localStorage.getItem(key), initialValue),
+  );
 
   useEffect(() => {
     if (!persistent) {
@@ -151,12 +165,11 @@ export function useStorage<T>(
   }, []);
 
   useEffect(() => {
-    const val = localStorage.getItem(key);
-    setStoredValue(val ? JSON.parse(val) : initialValue);
+    setStoredValue(parseStoredValue(localStorage.getItem(key), initialValue));
 
     const handleStorageChange = (event: StorageEvent) => {
       if (event.key === key) {
-        setStoredValue(JSON.parse(event.newValue as string));
+        setStoredValue(parseStoredValue(event.newValue, initialValue));
       }
     };
 
@@ -168,11 +181,18 @@ export function useStorage<T>(
   }, [key]);
   const updateStorage = (newValue: T) => {
     setStoredValue(newValue);
-    localStorage.setItem(key, JSON.stringify(newValue));
+    // JSON.stringify(undefined) returns undefined; setItem would coerce it to
+    // the string "undefined", which is not valid JSON on the next read.
+    const serialized = JSON.stringify(newValue);
+    if (serialized === undefined) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, serialized);
+    }
     window.dispatchEvent(
       new StorageEvent('storage', {
         key,
-        newValue: JSON.stringify(newValue),
+        newValue: serialized ?? null,
       }),
     );
   };


### PR DESCRIPTION
## Problem

`useStorage` parses localStorage in three places with bare `JSON.parse` and no guard:

1. the `useState` initializer,
2. the `[key]` effect re-read,
3. the `storage` event handler (where `event.newValue` is additionally `null` when the key is removed).

A stored literal `"undefined"`, an empty string, or malformed JSON therefore **throws during render** and crashes the consuming app. The hook can even poison itself: `setValue(undefined)` → `JSON.stringify(undefined)` → `undefined` → `setItem` coerces it to the string `"undefined"`, which fails to parse on every subsequent mount.

This is live in production: **biip-medziokle-web crash-loops at boot** for affected users ([Sentry #19949](https://sentry.biip.lt/organizations/biip/issues/19949/), release 1.3.2) — `UserProvider` calls `useStorage('isSubScribed', false, true)` at app start. App-side guards can't help since the parse happens inside the library.

## Fix

- `parseStoredValue(raw, fallback)` — returns `fallback` for `null` / `''` / `'undefined'` and on any `JSON.parse` failure; used at all three read sites. Legitimate stored `null` (`'null'`) still parses as before.
- `setValue(undefined)` now removes the key instead of persisting the literal string `"undefined"`, and the dispatched `StorageEvent` carries `newValue: null` (the standard removal signal).

Behaviour for valid JSON values is unchanged. Changeset included (patch).

## Verification

- `yarn build` (tsc + vite) — green
- `yarn lint` — same pre-existing findings as `main`, nothing new from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)