### PR TITLE
ci: run CI/deploy jobs on self-hosted am-github-runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   release-packages:
     name: Release package
-    runs-on: ubuntu-latest
+    runs-on: am-github-runner
     timeout-minutes: 10
     permissions:
       contents: write
@@ -51,7 +51,7 @@ jobs:
     name: Publish Storybook page
     needs: [ release-packages ]
     if: needs.release-packages.outputs.published == 'true'
-    runs-on: ubuntu-latest
+    runs-on: am-github-runner
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
## Kodėl

Org Actions spending limit blokuoja GitHub-hosted runnerius (`job was not started because recent account payments have failed or your spending limit needs to be increased`). Vakar dėl to krito HR deploy'ai. Standartas — naudoti jau egzistuojantį self-hosted `am-github-runner` (ARC, Default runner group, matomas visiems org repams).

## Kas pakeista

Inline CI/deploy jobų `runs-on: ubuntu-latest` → `am-github-runner`.

- Saugumo skenai (CodeQL / Checkov / Scorecards) **palikti** ant `ubuntu-latest`.
- Deploy'ai per reusable workflow'us automatiškai migruoja per **AplinkosMinisterija/reusable-workflows#32** (`runs-on` default flip) — jiems atskiro pakeitimo nereikia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)