### PR TITLE
fields: required label mark + SelectField getOptionValue

### DIFF
--- a/.changeset/shiny-fields-required.md
+++ b/.changeset/shiny-fields-required.md
@@ -1,0 +1,7 @@
+---
+'@aplinkosministerija/design-system': minor
+---
+
+Form fields: add `required` prop (renders a danger-colored " \*" mark after the label, visual only — validation stays with the consumer) to FieldWrapper and all label-carrying fields (TextField, TextAreaField, NumericField, PasswordField, PhoneField, SelectField, SimpleSelect, MultiSelectField, AsyncSelectField, AsyncMultiSelectField, CreatableMultiSelect, RadioOptions, DatePicker, DateField, TimePicker, TimeField).
+
+SelectField: add `getOptionValue` — when provided, `value` may be the option's primitive value (e.g. its id) and the selected option is resolved internally, so consumers no longer need to keep the whole option object in state.

--- a/src/components/AsyncMultiSelectField.tsx
+++ b/src/components/AsyncMultiSelectField.tsx
@@ -13,6 +13,7 @@ export interface SelectOption {
 export interface SelectFieldProps {
   texts?: OptionContainerTexts;
   label?: string;
+  required?: boolean;
   values?: any[];
   error?: string;
   showError?: boolean;
@@ -31,6 +32,7 @@ export interface SelectFieldProps {
 
 const AsyncMultiSelectField = ({
   label,
+  required,
   values = [],
   name,
   error,
@@ -72,6 +74,7 @@ const AsyncMultiSelectField = ({
     <FieldWrapper
       onClick={handleToggleSelect}
       label={label}
+      required={required}
       error={error}
       showError={showError}
       handleBlur={handleBlur}

--- a/src/components/AsyncSelectField.tsx
+++ b/src/components/AsyncSelectField.tsx
@@ -9,6 +9,7 @@ import TextFieldInput from './common/TextFieldInput';
 export interface AsyncSelectFieldProps {
   name: string;
   label?: string;
+  required?: boolean;
   value?: any;
   error?: string;
   showError?: boolean;
@@ -33,6 +34,7 @@ export interface AsyncSelectFieldProps {
 
 const AsyncSelectField = ({
   label,
+  required,
   value,
   error,
   showError = true,
@@ -90,6 +92,7 @@ const AsyncSelectField = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       error={error}
       showError={showError}
     >

--- a/src/components/CreatableMultiSelect.tsx
+++ b/src/components/CreatableMultiSelect.tsx
@@ -6,6 +6,7 @@ import OptionsContainer from './common/OptionsContainer';
 
 export interface CreatableMultiSelectProps {
   label?: string;
+  required?: boolean;
   values?: any;
   error?: string;
   showError?: boolean;
@@ -18,6 +19,7 @@ export interface CreatableMultiSelectProps {
 
 const CreatableMultiSelect = ({
   label,
+  required,
   values,
   error,
   showError = true,
@@ -61,6 +63,7 @@ const CreatableMultiSelect = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       error={error}
       handleBlur={handleBlur}
     >

--- a/src/components/DateField.tsx
+++ b/src/components/DateField.tsx
@@ -21,6 +21,7 @@ export interface DateFieldProps {
   error?: string;
   onChange: (date?: Date) => void;
   label?: string;
+  required?: boolean;
   name?: string;
   className?: string;
   maxDate?: Date | string;
@@ -42,6 +43,7 @@ const DateField = ({
   error,
   onChange,
   label,
+  required,
   disabled = false,
   padding,
   className,
@@ -191,6 +193,7 @@ const DateField = ({
           className={className}
           onChange={handleChange}
           label={label}
+          required={required}
           padding={padding}
           value={textValue}
           showError={showError}

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -20,6 +20,7 @@ export interface DateFieldProps {
   error?: string;
   onChange: (date?: Date) => void;
   label?: string;
+  required?: boolean;
   name?: string;
   className?: string;
   maxDate?: Date | string;
@@ -37,6 +38,7 @@ const DateField = ({
   error,
   onChange,
   label,
+  required,
   disabled = false,
   padding,
   className,
@@ -149,6 +151,7 @@ const DateField = ({
           className={className}
           onChange={handleChange}
           label={label}
+          required={required}
           padding={padding}
           value={textValue}
           showError={showError}

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -12,6 +12,7 @@ export interface SelectOption {
 
 export interface SelectFieldProps {
   label?: string;
+  required?: boolean;
   values: any[];
   error?: string;
   options: SelectOption[] | string[];
@@ -26,6 +27,7 @@ export interface SelectFieldProps {
 
 const MultiSelectField = ({
   label,
+  required,
   values = [],
   error,
   options,
@@ -56,7 +58,13 @@ const MultiSelectField = ({
   });
 
   return (
-    <FieldWrapper onClick={handleToggleSelect} label={label} error={error} handleBlur={handleBlur}>
+    <FieldWrapper
+      onClick={handleToggleSelect}
+      label={label}
+      required={required}
+      error={error}
+      handleBlur={handleBlur}
+    >
       <MultiTextField
         values={values}
         label={label}

--- a/src/components/NumericField.tsx
+++ b/src/components/NumericField.tsx
@@ -8,6 +8,7 @@ export interface NumericFieldProps {
   error?: string;
   showError?: boolean;
   label?: string;
+  required?: boolean;
   icon?: JSX.Element;
   className?: string;
   left?: JSX.Element;
@@ -33,6 +34,7 @@ const NumericField = ({
   name,
   error,
   label,
+  required,
   className,
   left,
   right,
@@ -82,6 +84,7 @@ const NumericField = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       bottomLabel={bottomLabel}
       subLabel={subLabel}
       secondLabel={secondLabel}

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -10,6 +10,7 @@ export interface TextFieldProps {
   error?: string;
   showError?: boolean;
   label?: string;
+  required?: boolean;
   className?: string;
   padding?: string;
   onChange?: (option?: any) => void;
@@ -28,6 +29,7 @@ const PasswordField = ({
   error,
   showError = true,
   label,
+  required,
   className,
   padding,
   onChange,
@@ -45,6 +47,7 @@ const PasswordField = ({
       secondLabel={secondLabel}
       className={className}
       label={label}
+      required={required}
       error={error}
       showError={showError}
     >

--- a/src/components/PhoneField.tsx
+++ b/src/components/PhoneField.tsx
@@ -7,6 +7,7 @@ export interface PhoneFieldProps {
   error?: string;
   showError?: boolean;
   label?: string;
+  required?: boolean;
   icon?: JSX.Element;
   className?: string;
   left?: JSX.Element;
@@ -28,6 +29,7 @@ const PhoneField = ({
   name,
   error,
   label,
+  required,
   className,
   left,
   right,
@@ -69,6 +71,7 @@ const PhoneField = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       error={error}
       showError={showError}
     >

--- a/src/components/RadioOptions.tsx
+++ b/src/components/RadioOptions.tsx
@@ -11,6 +11,7 @@ export interface RadioOptionsProps {
   className?: string;
   onChange: (option: any) => void;
   label?: string;
+  required?: boolean;
   disabled?: boolean;
   column?: boolean;
   oneLine?: boolean;
@@ -28,11 +29,12 @@ const RadioOptions = ({
   className,
   disabled,
   label,
+  required,
   ...rest
 }: RadioOptionsProps) => {
   return (
     <Container oneLine={oneLine} className={className}>
-      <FieldWrapper error={error} showError={showError} label={label}>
+      <FieldWrapper error={error} showError={showError} label={label} required={required}>
         <OptionsContainer column={column}>
           {options?.map((option, index) => {
             const key = `${name}_${option.value}`;

--- a/src/components/SelectField.tsx
+++ b/src/components/SelectField.tsx
@@ -9,6 +9,8 @@ import TextFieldInput from './common/TextFieldInput';
 export interface SelectFieldProps {
   name?: string;
   label?: string;
+  required?: boolean;
+  /** The selected option object; with `getOptionValue` — the selected option's VALUE (e.g. its id). */
   value?: any;
   error?: string;
   showError?: boolean;
@@ -18,6 +20,8 @@ export interface SelectFieldProps {
   onChange: (option: any) => void;
   disabled?: boolean;
   getOptionLabel: (option: any) => string | JSX.Element;
+  /** When provided, `value` is matched against options by this accessor, so consumers can pass a primitive value instead of the option object. */
+  getOptionValue?: (option: any) => any;
   getOptionComponent?: (option: any) => string | JSX.Element;
   className?: string;
   placeholder?: string;
@@ -30,6 +34,7 @@ export interface SelectFieldProps {
 
 const SelectField = ({
   label,
+  required,
   value,
   name,
   error,
@@ -41,6 +46,7 @@ const SelectField = ({
   left,
   padding,
   getOptionLabel,
+  getOptionValue,
   getOptionComponent,
   onChange,
   disabled,
@@ -49,6 +55,13 @@ const SelectField = ({
   ariaLabelRemove = 'Pašalinti',
   ariaLabelDropDownIcon = 'Išskleidimo ikonėlė',
 }: SelectFieldProps) => {
+  // With getOptionValue the consumer passes the option's value — resolve the
+  // option object internally so display/selection keep working.
+  const selected =
+    getOptionValue && value != null
+      ? (options || []).find((option) => getOptionValue(option) === value)
+      : value;
+
   const {
     suggestions,
     input,
@@ -65,11 +78,11 @@ const SelectField = ({
     getOptionLabel,
     refreshOptions,
     dependantId,
-    value,
+    value: selected,
   });
 
   const handleKeyDown = useKeyAction(() => onChange(undefined), disabled);
-  const showDeleteIcon = !!value && !!clearable && !disabled;
+  const showDeleteIcon = selected != null && !!clearable && !disabled;
 
   return (
     <FieldWrapper
@@ -78,6 +91,7 @@ const SelectField = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       error={error}
       showError={showError}
     >
@@ -92,7 +106,7 @@ const SelectField = ({
             {showDeleteIcon && (
               <IconButton
                 type="button"
-                aria-label={`${ariaLabelRemove} ${typeof getOptionLabel(value) === 'string' ? getOptionLabel(value) : ''}`}
+                aria-label={`${ariaLabelRemove} ${typeof getOptionLabel(selected) === 'string' ? getOptionLabel(selected) : ''}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   !disabled && onChange(undefined);
@@ -127,13 +141,13 @@ const SelectField = ({
         }}
         disabled={disabled}
         placeholder={
-          value
+          selected
             ? getOptionComponent
-              ? getOptionComponent(value)
-              : getOptionLabel(value)
+              ? getOptionComponent(selected)
+              : getOptionLabel(selected)
             : placeholder
         }
-        selectedValue={value}
+        selectedValue={selected}
       />
       <OptionsContainer
         options={suggestions}

--- a/src/components/SimpleSelect.tsx
+++ b/src/components/SimpleSelect.tsx
@@ -8,6 +8,7 @@ import TextFieldInput from './common/TextFieldInput';
 interface SimpleSelectProps {
   name?: string;
   label?: string;
+  required?: boolean;
   value?: any;
   error?: string;
   showError?: boolean;
@@ -25,6 +26,7 @@ interface SimpleSelectProps {
 
 const SimpleSelect = ({
   label,
+  required,
   value,
   name,
   error,
@@ -59,6 +61,7 @@ const SimpleSelect = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       error={error}
       showError={showError}
     >

--- a/src/components/TextAreaField.tsx
+++ b/src/components/TextAreaField.tsx
@@ -9,6 +9,7 @@ export interface TextFieldProps {
   error?: string;
   showError?: boolean;
   label?: string;
+  required?: boolean;
   icon?: JSX.Element;
   className?: string;
   left?: JSX.Element;
@@ -27,6 +28,7 @@ const TextAreaField = ({
   error,
   showError = true,
   label,
+  required,
   className,
   onChange,
   onClick,
@@ -51,6 +53,7 @@ const TextAreaField = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       htmlFor={id}
       error={error}
       showError={showError}

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -7,6 +7,7 @@ export interface TextFieldProps {
   error?: string;
   showError?: boolean;
   label?: string;
+  required?: boolean;
   icon?: JSX.Element;
   className?: string;
   left?: JSX.Element;
@@ -32,6 +33,7 @@ const TextField = ({
   showError = true,
   readOnly = false,
   label,
+  required,
   className,
   left,
   right,
@@ -51,6 +53,7 @@ const TextField = ({
       padding={padding}
       className={className}
       label={label}
+      required={required}
       subLabel={subLabel}
       secondLabel={secondLabel}
       error={error}

--- a/src/components/TimeField.tsx
+++ b/src/components/TimeField.tsx
@@ -33,6 +33,7 @@ export interface CustomTimePickerProps {
   error?: string;
   onChange: (time?: string) => void;
   label?: string;
+  required?: boolean;
   name?: string;
   className?: string;
   maxTime?: string;
@@ -48,6 +49,7 @@ const TimeField = ({
   error,
   onChange,
   label,
+  required,
   disabled = false,
   padding,
   className,
@@ -183,6 +185,7 @@ const TimeField = ({
           className={className}
           onChange={handleChange}
           label={label}
+          required={required}
           padding={padding}
           value={inputValue}
           showError={showError}

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -8,6 +8,7 @@ import TextField from './TextField';
 
 export interface TimepickerProps {
   label?: string;
+  required?: boolean;
   value?: Date;
   error?: string;
   padding?: string;
@@ -24,6 +25,7 @@ const TimePicker = ({
   error,
   onChange,
   label,
+  required,
   disabled,
   padding,
   className,
@@ -84,6 +86,7 @@ const TimePicker = ({
       <StyledTextInput
         readOnly={true}
         label={label}
+        required={required}
         padding={padding}
         value={time ? format(new Date(time), 'HH:mm') : ''}
         error={error}

--- a/src/components/common/FieldWrapper.tsx
+++ b/src/components/common/FieldWrapper.tsx
@@ -6,6 +6,8 @@ export interface FieldWrapperProps {
   error?: string;
   showError?: boolean;
   label?: string;
+  /** Renders the required mark (" *") after the label. Visual only — validation stays with the consumer. */
+  required?: boolean;
   className?: string;
   padding?: string;
   onClick?: () => void;
@@ -22,6 +24,7 @@ const FieldWrapper = ({
   error,
   showError = true,
   label = '',
+  required = false,
   className,
   padding = '0',
   onClick,
@@ -53,6 +56,7 @@ const FieldWrapper = ({
           <LabelContainer>
             <Label id={labelAriaValue} htmlFor={htmlFor}>
               {label}
+              {required && <RequiredMark aria-hidden="true"> *</RequiredMark>}
             </Label>
             {!!subLabel && (
               <SubLabel id={subLabelAriaValue} aria-labelledby={subLabelAriaValue}>
@@ -96,6 +100,11 @@ const Label = styled.label`
   font-size: ${({ theme }) => theme.fonts?.fieldLabels || 1.4}rem;
   font-weight: ${({ theme }) => theme.fontWeight?.fieldLabels || 400};
   color: ${({ theme }) => theme.colors.fields?.label || '#101010'};
+`;
+
+const RequiredMark = styled.span`
+  color: ${({ theme }) => theme.colors?.danger || '#fe5b78'};
+  white-space: pre;
 `;
 
 const LabelContainer = styled.div`


### PR DESCRIPTION
## What
- `required` prop on FieldWrapper and every label-carrying field (TextField, TextAreaField, NumericField, PasswordField, PhoneField, SelectField, SimpleSelect, MultiSelectField, AsyncSelectField, AsyncMultiSelectField, CreatableMultiSelect, RadioOptions, DatePicker, DateField, TimePicker, TimeField) — renders a danger-colored " *" mark after the label. Visual only; validation stays with the consumer (native `required` is deliberately not set).
- `getOptionValue` on SelectField — when provided, `value` may be the option's primitive value (e.g. its id); the component resolves the selected option internally. Mirrors the existing MultiSelectField API. Backwards compatible: without `getOptionValue` the behaviour is unchanged.

## Why
Consumer apps (first user: biip-alis-admin-web) keep re-implementing the required mark and the option-object⇄value juggling in local wrappers around the design system. With these two gaps closed the fields can be used directly.

## Notes
- Changeset included (minor).
- Pre-existing lint errors in `stories/` and `utils/boundaries` are untouched (they fail on `main` too); the changed component files add no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)